### PR TITLE
Fixing duplicate button IDs in CRUD

### DIFF
--- a/streamlit_sql/sql_iu.py
+++ b/streamlit_sql/sql_iu.py
@@ -359,6 +359,7 @@ class SqlUi:
             self.btns_container,
             qtty_rows,
             ss.stsql_opened,
+            f"{self.base_key}_crud_btn_sql_ui",
         )
 
         if action == "add":

--- a/streamlit_sql/update_model.py
+++ b/streamlit_sql/update_model.py
@@ -111,7 +111,7 @@ class UpdateRow:
         wrap_show_update()
 
 
-def action_btns(container: DeltaGenerator, qtty_selected: int, opened: bool):
+def action_btns(container: DeltaGenerator, qtty_selected: int, opened: bool, base_key: str = ""):
     set_state("stsql_action", "")
     disabled_add = qtty_selected > 0
     disabled_edit = qtty_selected != 1
@@ -127,6 +127,7 @@ def action_btns(container: DeltaGenerator, qtty_selected: int, opened: bool):
             type="secondary",
             disabled=disabled_add,
             use_container_width=True,
+            key=f"{base_key}_add"
         )
 
         edit_btn = edit_col.button(
@@ -136,6 +137,7 @@ def action_btns(container: DeltaGenerator, qtty_selected: int, opened: bool):
             type="secondary",
             disabled=disabled_edit,
             use_container_width=True,
+            key=f"{base_key}_edit"
         )
 
         del_btn = del_col.button(
@@ -145,6 +147,7 @@ def action_btns(container: DeltaGenerator, qtty_selected: int, opened: bool):
             type="primary",
             disabled=disabled_delete,
             use_container_width=True,
+            key=f"{base_key}_del"
         )
 
         if opened:


### PR DESCRIPTION
This fixes the error I got when using several forms on different tabs in the same page.
Hope this makes sense!